### PR TITLE
New method whereOrClauseArray to support clause OR sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Name          | Description   | Return
 `fromTableStr` | Specify the table name to select from. *Tip: You can also include an alias here `return 'mytable a';`*| **String **
 `joinArray` | Join additional tables for DataTable columns to reference.  *Tip: Join Types CAN be specifed by using a pipe in the key value `'table_to_join b&#124;left outer'`*| **Assoc. Array** *Key*=Table To Join *Value*=SQL Join Expression.
 `whereClauseArray`| Append Static SQL to the generated Where Clause| **Assoc. Array** *Key*= Column Name *Value*=Value To Filter **OR** *NULL*
+`whereOrClauseArray`| Append Static SQL to the generated Where OR Clause| **Assoc. Array** *Key*= Column Name *Value*=Value To Filter
 
 Methods
 ----
@@ -133,6 +134,10 @@ Basic DatatableModel Implementation
     	public function whereClauseArray(){
     		return NULL;
     	}
+		
+		public function whereOrClauseArray(){
+			return null;
+    	}
    }
 ```
 
@@ -166,6 +171,10 @@ More Advanced DatatableModel Implementation
 			return array(
 				'u.id' => $this -> ion_auth -> get_user_id() 
 				);
+    	}
+		
+		public function whereOrClauseArray(){
+			return null;
     	}
    }
 ```

--- a/libraries/Datatable.php
+++ b/libraries/Datatable.php
@@ -418,6 +418,12 @@ class Datatable
         if (is_null($wArray) === FALSE && is_array($wArray) === TRUE && count($wArray) > 0) {
             $this->CI->db->where($wArray, $this->protectIdentifiers);
         }
+		
+		//append a static where 'OR' clause to what the user has filtered, if the model tells us to do so
+        $wOrArray = $this->model->whereOrClauseArray();
+        if (is_null($wArray) === FALSE && is_array($wArray) === TRUE && count($wArray) > 0) {
+            $this->CI->db->or_where($wOrArray, $this->protectIdentifiers);
+        }
 
         return $debug;
     }
@@ -454,6 +460,14 @@ interface DatatableModel
      * when not filtering by additional criteria
      */
     public function whereClauseArray();
+	
+	/**
+     *
+     * @return
+     *    Static where OR clause to be appended to all search queries.  Return NULL or empty array
+     * when not filtering by additional criteria
+     */
+    public function whereOrClauseArray();
 }
 
 // END Datatable Class


### PR DESCRIPTION
Add method in interface Datatable whereOrClauseArray for allow query with clause where OR

public function whereOrClauseArray();

Exemple use:

public function whereOrClauseArray() {
        return array(
            'p.status' => 2
        );
}
