### PR TITLE
Apply setColumnSearchType settings to global searches

### DIFF
--- a/libraries/Datatable.php
+++ b/libraries/Datatable.php
@@ -402,14 +402,10 @@ class Datatable
         $globSearch = $f->post_get('search');
         if ($globSearch['value'] !== '') {
             $gSearchVal = $globSearch['value'];
-            $sqlOr = '';
-            $op = '';
             foreach ($searchableColumns as $c) {
-                $sqlOr .= $op . $c . ' LIKE \'' . $this->CI->db->escape_like_str($gSearchVal) . '%\'';
-                $op = ' OR ';
+                $searchType = $this->getColumnSearchType($c);
+                $this->CI->db->or_like($c, $gSearchVal, $searchType);
             }
-
-            $this->CI->db->where('(' . $sqlOr . ')');
         }
 
 


### PR DESCRIPTION
Modified the sqlJoinsAndWhere function to use the wildcard settings from setColumnSearchType for global searches and replaced the raw MySQL LIKE query with the $this->db->or_like() function from CodeIgniter Query Builder.
