### PR TITLE
fix ambiguous id

### DIFF
--- a/libraries/Datatable.php
+++ b/libraries/Datatable.php
@@ -190,7 +190,8 @@ class Datatable
             $selectArray[] = $c['data'];
         }
         if ($this->rowIdCol !== NULL && in_array($this->rowIdCol, $selectArray) === FALSE) {
-            $selectArray[] = $this->rowIdCol;
+            $tableName = explode('.',$selectArray[0])[0];
+            $selectArray[] = "{$tableName}.{$this->rowIdCol}";
         }
 
         //put the select string together


### PR DESCRIPTION
When I was on a join, and both tables have as its primary key "id" that generated an error ambiguity, which has been fixed enlarge the table before select id.
