### PR TITLE
Sorting for appendToSelectStr field DB error

### DIFF
--- a/libraries/Datatable.php
+++ b/libraries/Datatable.php
@@ -213,12 +213,7 @@ class Datatable
                 $colName = $columnIdxArray[$o['column']];
                 //handle custom sql expressions/subselects
                 if (substr($colName, 0, 2) === '$.') {
-                    $aliasKey = substr($colName, 2);
-                    if (isset($customExpArray[$aliasKey]) === FALSE) {
-                        throw new Exception('Alias[' . $aliasKey . '] Could Not Be Found In appendToSelectStr() Array');
-                    }
-
-                    $colName = $customExpArray[$aliasKey];
+                    $colName = substr($colName, 2);
                 }
                 $this->CI->db->order_by($colName, $o['dir']);
             }


### PR DESCRIPTION
Ordering by appendToSelectStr field causing DB error in Codeigniter 3.1.0, haven't tested on other version.

Resolution: 

To use original colname with removed $. should do the trick. 
Current version uses $colName = $customExpArray[$aliasKey]; causing DB append sorting method to end of each concat individual value